### PR TITLE
Shared socket

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-component",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "homepage": "https://github.com/wburgers/websocket-component",
   "description": "A websocket element wrapper",
   "keywords": ["web-components"],

--- a/bower.json
+++ b/bower.json
@@ -15,15 +15,14 @@
     "bower_components"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^2.0.0-rc.2"
+    "polymer": "Polymer/polymer#^2.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
-    "web-component-tester": "v6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.7"
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "resolutions": {
-    "polymer": "^2.0.0-rc.2"
+    "polymer": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,10 +15,15 @@
     "bower_components"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0"
+    "polymer": "Polymer/polymer#^2.0.0-rc.2"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-		"web-component-tester": "*"
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
+    "web-component-tester": "v6.0.0-prerelease.5",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.7"
+  },
+  "resolutions": {
+    "polymer": "^2.0.0-rc.2"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -52,21 +52,27 @@ This code may only be used under the BSD style license found at http://wburgers.
                     socket-id="11"
                     url="wss://echo.websocket.org" auto handle-visibility
                     on-websocket-open="_sendSharedWebsocketMessage"
-                    on-websocket-message="_addSharedWebsocketMessage">
+                    on-websocket-message="_addSharedWebsocketMessage"
+                    on-websocket-ready="_addReadyMessage"
+            >
             </shared-websocket-component>
             <shared-websocket-component
                     id="websocket_111"
                     socket-id="11"
                     url="wss://echo.websocket.org" auto handle-visibility
                     on-websocket-open="_sendSharedWebsocketMessage"
-                    on-websocket-message="_addSharedWebsocketMessage">
+                    on-websocket-message="_addSharedWebsocketMessage"
+                    on-websocket-ready="_addReadyMessage"
+            >
             </shared-websocket-component>
             <shared-websocket-component
                     id="websocket_120"
                     socket-id="12"
                     url="wss://echo.websocket.org" auto handle-visibility
                     on-websocket-open="_sendSharedWebsocketMessage"
-                    on-websocket-message="_addSharedWebsocketMessage">
+                    on-websocket-message="_addSharedWebsocketMessage"
+                    on-websocket-ready="_addReadyMessage"
+            >
             </shared-websocket-component>
             <pre>
           <template is="dom-repeat" items="[[sharedWebsocketMessages]]">
@@ -112,6 +118,9 @@ This code may only be used under the BSD style license found at http://wburgers.
       _addSharedWebsocketMessage(event) {
         console.log("Message received from shared websocket " + event.target.id + " echo websocket server:", event.detail.data);
         this.push('sharedWebsocketMessages', (new Date()).toLocaleTimeString() + ' -- ' + event.target.id + "  received  " + event.detail.data);
+      }
+      _addReadyMessage(event) {
+        this.push('sharedWebsocketMessages', (new Date()).toLocaleTimeString() + ' -- ' + event.target.id + "  is ready ");
       }
 
       _sendSharedWebsocketMessage(event) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,11 @@ This code may only be used under the BSD style license found at http://wburgers.
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>websocket-component Demo</title>
 
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+
+  <link rel="import" href="../../polymer/polymer.html">
+
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../websocket-component.html">
@@ -27,12 +32,12 @@ This code may only be used under the BSD style license found at http://wburgers.
         <h3>Standard websocket-component single request</h3>
         Check your console!
         <demo-snippet class="centered-demo">
-<!--            <websocket-component
+            <websocket-component
                     id="websocket"
                     url="wss://echo.websocket.org" auto handle-visibility
                     on-websocket-open="_sendWebsocketMessage"
                     on-websocket-message="_addWebsocketMessage">
-            </websocket-component>-->
+            </websocket-component>
             <pre>
           <template is="dom-repeat" items="[[websocketMessages]]">
               [[item]]
@@ -74,51 +79,52 @@ This code may only be used under the BSD style license found at http://wburgers.
 </dom-module>
 <script>
   const ws_element = document.getElementById('websocket');
+  addEventListener('WebComponentsReady', function() {
+    class WebsocketDemo extends Polymer.Element {
+      static get is() {
+        return "websocket-demo";
+      }
 
-  class WebsocketDemo extends Polymer.Element {
-    static get is() {
-      return "websocket-demo";
-    }
-
-    static get properties() {
-      return {
-        websocketMessages: {
-          type: Array,
-          notify: true,
-          value: () => []
-        },
-        sharedWebsocketMessages: {
-          type: Array,
-          notify: true,
-          value: () => []
+      static get properties() {
+        return {
+          websocketMessages: {
+            type: Array,
+            notify: true,
+            value: () => []
+          },
+          sharedWebsocketMessages: {
+            type: Array,
+            notify: true,
+            value: () => []
+          }
         }
+      }
+
+      _addWebsocketMessage(event) {
+        console.log("Message received from echo websocket server:", event.detail.data);
+        this.push('websocketMessages', (new Date()).toLocaleTimeString() + ' -- ' + event.detail.data);
+      }
+
+      _sendWebsocketMessage(event) {
+        this.$.websocket.send("test");
+      }
+
+      _addSharedWebsocketMessage(event) {
+        console.log("Message received from shared websocket " + event.target.id + " echo websocket server:", event.detail.data);
+        this.push('sharedWebsocketMessages', (new Date()).toLocaleTimeString() + ' -- ' + event.target.id + "  received  " + event.detail.data);
+      }
+
+      _sendSharedWebsocketMessage(event) {
+        const wsElement = event.target;
+        wsElement.send("My name is " + wsElement.id);
+        window.setTimeout(() => {
+          wsElement.send("2nd shared message from " + wsElement.id)
+        }, 1000);
       }
     }
 
-    _addWebsocketMessage(event) {
-      console.log("Message received from echo websocket server:", event.detail.data);
-      this.push('websocketMessages', (new Date()).toLocaleTimeString() + ' -- ' +  event.detail.data);
-    }
-
-    _sendWebsocketMessage(event) {
-      this.$.websocket.send("test");
-    }
-
-    _addSharedWebsocketMessage(event) {
-      console.log("Message received from shared websocket " +  event.path[0].id +" echo websocket server:", event.detail.data);
-      this.push('sharedWebsocketMessages', (new Date()).toLocaleTimeString() + ' -- ' + event.path[0].id + "  received  " + event.detail.data);
-    }
-
-    _sendSharedWebsocketMessage(event) {
-      event.path[0].send("My name is " + event.path[0].id);
-      window.setTimeout(() => {
-        event.path[0].send("2nd shared message from " + event.path[0].id)
-      }, 1000);
-    }
-  }
-
-  window.customElements.define(WebsocketDemo.is, WebsocketDemo);
-
+    window.customElements.define(WebsocketDemo.is, WebsocketDemo);
+  });
 </script>
 
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,27 +4,36 @@ This code may only be used under the BSD style license found at http://wburgers.
 -->
 <!doctype html>
 <html>
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<title>websocket-component Demo</title>
-		<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
-		<link rel="import" href="../websocket-component.html">
-	</head>
-	<body>
-		Check your console!
-		<websocket-component id="websocket" url="wss://echo.websocket.org" auto handle-visibility></websocket-component>
-		<script>
-			var ws_element = document.getElementById('websocket');
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>websocket-component Demo</title>
 
-			document.addEventListener('websocket-message', function(event) {
-				console.log("Message received from echo websocket server:", event.detail.data);
-			});
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../websocket-component.html">
 
-			document.addEventListener('websocket-open', function() {
-				ws_element.send("test");
-			});
-		</script>
+  <style is="custom-style" include="demo-pages-shared-styles">
+  </style>
+</head>
+<body>
+Check your console!
+<demo-snippet>
+  <template>
+    <websocket-component id="websocket" url="wss://echo.websocket.org" auto handle-visibility></websocket-component>
+  </template>
+</demo-snippet>
+<script>
+  const ws_element = document.getElementById('websocket');
 
-	</body>
+  ws_element.addEventListener('websocket-message', function (event) {
+    console.log("Message received from echo websocket server:", event.detail.data);
+  });
+
+  ws_element.addEventListener('websocket-open', function () {
+    ws_element.send("test");
+  });
+</script>
+
+</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,27 +12,113 @@ This code may only be used under the BSD style license found at http://wburgers.
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../websocket-component.html">
+  <link rel="import" href="../shared-websocket-component.html">
 
   <style is="custom-style" include="demo-pages-shared-styles">
   </style>
 </head>
 <body>
-Check your console!
-<demo-snippet>
-  <template>
-    <websocket-component id="websocket" url="wss://echo.websocket.org" auto handle-visibility></websocket-component>
-  </template>
-</demo-snippet>
+
+<websocket-demo></websocket-demo>
+
+<dom-module id="websocket-demo">
+    <template>
+    <div class="vertical-section-container centered">
+        <h3>Standard websocket-component single request</h3>
+        Check your console!
+        <demo-snippet class="centered-demo">
+<!--            <websocket-component
+                    id="websocket"
+                    url="wss://echo.websocket.org" auto handle-visibility
+                    on-websocket-open="_sendWebsocketMessage"
+                    on-websocket-message="_addWebsocketMessage">
+            </websocket-component>-->
+            <pre>
+          <template is="dom-repeat" items="[[websocketMessages]]">
+              [[item]]
+          </template>
+          </pre>
+        </demo-snippet>
+        <h3>Shared websocket-component multi request</h3>
+        Check your console!
+        <demo-snippet class="centered-demo">
+            <shared-websocket-component
+                    id="websocket_110"
+                    socket-id="11"
+                    url="wss://echo.websocket.org" auto handle-visibility
+                    on-websocket-open="_sendSharedWebsocketMessage"
+                    on-websocket-message="_addSharedWebsocketMessage">
+            </shared-websocket-component>
+            <shared-websocket-component
+                    id="websocket_111"
+                    socket-id="11"
+                    url="wss://echo.websocket.org" auto handle-visibility
+                    on-websocket-open="_sendSharedWebsocketMessage"
+                    on-websocket-message="_addSharedWebsocketMessage">
+            </shared-websocket-component>
+            <shared-websocket-component
+                    id="websocket_120"
+                    socket-id="12"
+                    url="wss://echo.websocket.org" auto handle-visibility
+                    on-websocket-open="_sendSharedWebsocketMessage"
+                    on-websocket-message="_addSharedWebsocketMessage">
+            </shared-websocket-component>
+            <pre>
+          <template is="dom-repeat" items="[[sharedWebsocketMessages]]">
+              [[item]]
+          </template>
+          </pre>
+        </demo-snippet>
+    </div>
+    </template>
+</dom-module>
 <script>
   const ws_element = document.getElementById('websocket');
 
-  ws_element.addEventListener('websocket-message', function (event) {
-    console.log("Message received from echo websocket server:", event.detail.data);
-  });
+  class WebsocketDemo extends Polymer.Element {
+    static get is() {
+      return "websocket-demo";
+    }
 
-  ws_element.addEventListener('websocket-open', function () {
-    ws_element.send("test");
-  });
+    static get properties() {
+      return {
+        websocketMessages: {
+          type: Array,
+          notify: true,
+          value: () => []
+        },
+        sharedWebsocketMessages: {
+          type: Array,
+          notify: true,
+          value: () => []
+        }
+      }
+    }
+
+    _addWebsocketMessage(event) {
+      console.log("Message received from echo websocket server:", event.detail.data);
+      this.push('websocketMessages', (new Date()).toLocaleTimeString() + ' -- ' +  event.detail.data);
+    }
+
+    _sendWebsocketMessage(event) {
+      this.$.websocket.send("test");
+    }
+
+    _addSharedWebsocketMessage(event) {
+      console.log("Message received from shared websocket " +  event.path[0].id +" echo websocket server:", event.detail.data);
+      this.push('sharedWebsocketMessages', (new Date()).toLocaleTimeString() + ' -- ' + event.path[0].id + "  received  " + event.detail.data);
+    }
+
+    _sendSharedWebsocketMessage(event) {
+      event.path[0].send("My name is " + event.path[0].id);
+      window.setTimeout(() => {
+        event.path[0].send("2nd shared message from " + event.path[0].id)
+      }, 1000);
+    }
+  }
+
+  window.customElements.define(WebsocketDemo.is, WebsocketDemo);
+
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ This code may only be used under the BSD style license found at http://wburgers.
 
 	  <title>Websocket-component</title>
 
-	  <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+	  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
 
 	  <link rel="import" href="../polymer/polymer.html">
 	  <link rel="import" href="../iron-component-page/iron-component-page.html">

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/* eslint no-console: ["error", { allow: ["info"] }] */
+
+console.info(
+  'Service worker disabled for development, will be generated at build time.'
+);

--- a/shared-websocket-component.html
+++ b/shared-websocket-component.html
@@ -37,27 +37,35 @@ Example:
          * Open the connection manually. May throw errors when already connected or no url is specified.
          */
         open() {
-          if (!this || !this.url || this.url === "") {
+          if (!this.url || this.url === "") {
             throw new Error("shared-websocket-component(open): no url specified.");
           }
-          if(!this.socketId || this.socketId === "") {
+          if (!this.socketId || this.socketId === "") {
             throw new Error("shared-websocket-component(open): no socketId specified.");
           }
           if (this._ws) {
             throw new Error("shared-websocket-component(open): already connected");
           }
           this._ws = this.getOrCreateSocket(this.url, this.protocols)
-          this._ws.onopen = this._onwsopen.bind(this);
-          this._ws.onerror = this._onwserror.bind(this);
-          this._ws.onmessage = this._onwsmessage.bind(this);
-          this._ws.onclose = this._onwsclose.bind(this);
+          const addEvent = (name, callback) => {
+            //TODO: strange workaround for the test case to pass, why is addEventListener undefined???!!
+            if(this._ws.addEventListener) {
+              this._ws.addEventListener(name, callback.bind(this));
+            } else {
+              this._ws['on' + name] = callback.bind(this);
+            }
+          };
+          addEvent("open", this._onwsopen);
+          addEvent("error", this._onwserror);
+          addEvent("message", this._onwsmessage);
+          addEvent("close", this._onwsclose);
         }
 
         /**
          * Close the connection manually. Trows an error when the websocket is not connected.
          */
         close() {
-          if (!this || !this._ws) {
+          if (!this._ws) {
             throw new Error("shared-websocket-component(close): not connected.");
           }
           this._ws.close();

--- a/shared-websocket-component.html
+++ b/shared-websocket-component.html
@@ -1,0 +1,71 @@
+<!--
+Copyright (c) 2016 Willem Burgers.
+							2017 Sebastian Tilsch
+All rights reserved.
+This code may only be used under the BSD style license found at http://wburgers.github.io/LICENSE.txt
+-->
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="websocket-component.html">
+<link rel="import" href="websocket-sharing-behavior.html">
+
+<!--
+A Polymer wrapper for a websocket connection that is shared among certain instances by a ID.
+
+Example:
+
+    <shared-websocket-component socket-id="someID" auto handle-visibility url="wss://echo.websocket.org"></websocket-component>
+
+@element shared-websocket-component
+@demo demo/index.html
+-->
+
+<dom-module id="shared-websocket-component">
+    <template>
+        <style>
+            :host {
+                display: none;
+            }
+        </style>
+    </template>
+    <script>
+      class SharedWebsocketComponent extends WebsocketSharingBehavior( WebsocketComponentBehavior(Polymer.Element) ) {
+        static get is() {
+          return "shared-websocket-component";
+        }
+
+        /**
+         * Open the connection manually. May throw errors when already connected or no url is specified.
+         */
+        open() {
+          if (!this || !this.url || this.url === "") {
+            throw new Error("shared-websocket-component(open): no url specified.");
+          }
+          if(!this.socketId || this.socketId === "") {
+            throw new Error("shared-websocket-component(open): no socketId specified.");
+          }
+          if (this._ws) {
+            throw new Error("shared-websocket-component(open): already connected");
+          }
+          this._ws = this.getOrCreateSocket(this.url, this.protocols)
+          this._ws.onopen = this._onwsopen.bind(this);
+          this._ws.onerror = this._onwserror.bind(this);
+          this._ws.onmessage = this._onwsmessage.bind(this);
+          this._ws.onclose = this._onwsclose.bind(this);
+        }
+
+        /**
+         * Close the connection manually. Trows an error when the websocket is not connected.
+         */
+        close() {
+          if (!this || !this._ws) {
+            throw new Error("shared-websocket-component(close): not connected.");
+          }
+          this._ws.close();
+          this._ws = null;
+          this.removeWebsocket()
+        }
+      }
+
+      window.customElements.define(SharedWebsocketComponent.is, SharedWebsocketComponent);
+    </script>
+</dom-module>

--- a/shared-websocket-component.html
+++ b/shared-websocket-component.html
@@ -33,6 +33,15 @@ Example:
           return "shared-websocket-component";
         }
 
+        static get properties() {
+          return {
+            _wsReadyFired: {
+              type: Boolean,
+              value: false
+            }
+          };
+        }
+
         /**
          * Open the connection manually. May throw errors when already connected or no url is specified.
          */
@@ -59,6 +68,10 @@ Example:
           addEvent("error", this._onwserror);
           addEvent("message", this._onwsmessage);
           addEvent("close", this._onwsclose);
+          if(this.status === 1 && !this._wsReadyFired) {
+            this._wsReadyFired = true;
+            this.dispatchEvent(new CustomEvent("websocket-ready"));
+          }
         }
 
         /**
@@ -72,6 +85,14 @@ Example:
           this._ws = null;
           this.removeWebsocket()
         }
+        _onwsopen() {
+          this.dispatchEvent(new CustomEvent("websocket-open"));
+          if(!this._wsReadyFired) {
+            this._wsReadyFired = true;
+            this.dispatchEvent(new CustomEvent("websocket-ready"));
+          }
+        }
+
       }
 
       window.customElements.define(SharedWebsocketComponent.is, SharedWebsocketComponent);

--- a/shared-websocket-component.html
+++ b/shared-websocket-component.html
@@ -86,7 +86,7 @@ Example:
           this.removeWebsocket()
         }
         _onwsopen() {
-          this.dispatchEvent(new CustomEvent("websocket-open"));
+          super._onwsopen();
           if(!this._wsReadyFired) {
             this._wsReadyFired = true;
             this.dispatchEvent(new CustomEvent("websocket-ready"));

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -8,7 +8,7 @@ This code may only be used under the BSD style license found at http://wburgers.
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 	<script src="../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../websocket-component.html">
@@ -65,11 +65,11 @@ This code may only be used under the BSD style license found at http://wburgers.
 			});
 
 			test('open without url throws exception', function() {
-				expect(websocketElementWithoutURL.open).to.throw(Error, 'websocket-component(open): no url specified.');
+				expect(() => websocketElementWithoutURL.open()).to.throw(Error, 'websocket-component(open): no url specified.');
 			});
 
 			test('close without an open connection throws error', function() {
-				expect(websocketElementWithoutURL.close).to.throw(Error, 'websocket-component(close): not connected.');
+				expect(() => websocketElementWithoutURL.close()).to.throw(Error, 'websocket-component(close): not connected.');
 			});
 
 			test('send without an open connection throws error', function() {

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,9 @@ This code may only be used under the BSD style license found at http://wburgers.
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
         'basic-test.html',
-		'basic-test.html?dom=shadow'
+		'basic-test.html?dom=shadow',
+        'shared-basic-test.html',
+        'shared-basic-test.html?dom=shadow',
       ]);
     </script>
 	</body>

--- a/test/shared-basic-test.html
+++ b/test/shared-basic-test.html
@@ -8,7 +8,7 @@ This code may only be used under the BSD style license found at http://wburgers.
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 	<script src="../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../shared-websocket-component.html">
@@ -72,11 +72,11 @@ This code may only be used under the BSD style license found at http://wburgers.
 			});
 
 			test('open without url throws exception', function() {
-				expect(websocketElementWithoutURL.open).to.throw(Error, 'shared-websocket-component(open): no url specified.');
+				expect(() => websocketElementWithoutURL.open()).to.throw(Error, 'shared-websocket-component(open): no url specified.');
 			});
 
 			test('close without an open connection throws error', function() {
-				expect(websocketElementWithoutURL.close).to.throw(Error, 'shared-websocket-component(close): not connected.');
+				expect(() => websocketElementWithoutURL.close()).to.throw(Error, 'shared-websocket-component(close): not connected.');
 			});
 
 			test('send without an open connection throws error', function() {
@@ -86,7 +86,7 @@ This code may only be used under the BSD style license found at http://wburgers.
 			});
 
 			test('element without socket-id throws error', function() {
-			  expect(websocketElementWithoutSocketId.open).to.throw(Error, 'shared-websocket-component(open): no socketId specified.');
+			  expect(() => websocketElementWithoutSocketId.open()).to.throw(Error, 'shared-websocket-component(open): no socketId specified.');
 			});
 
 			test('element with a url and a socket-id loads ok', function() {

--- a/test/shared-basic-test.html
+++ b/test/shared-basic-test.html
@@ -1,0 +1,133 @@
+<!--
+Copyright (c) 2016 Willem Burgers. All rights reserved.
+This code may only be used under the BSD style license found at http://wburgers.github.io/LICENSE.txt
+-->
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+	<script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../shared-websocket-component.html">
+  </head>
+  <body>
+
+    <test-fixture id="websocketComponentWithoutURL">
+		<template>
+			<shared-websocket-component></shared-websocket-component>
+		</template>
+	</test-fixture>
+
+	<test-fixture id="websocketComponentWithoutSocketId">
+		<template>
+			<shared-websocket-component url="ws://echo.websocket.org"></shared-websocket-component>
+		</template>
+	</test-fixture>
+
+	<test-fixture id="websocketComponentWithURLAndSocketId">
+		<template>
+			<shared-websocket-component socket-id="1" url="ws://echo.websocket.org"></shared-websocket-component>
+		</template>
+	</test-fixture>
+
+	<test-fixture id="websocketComponentWithActiveConnection">
+		<template>
+			<shared-websocket-component socket-id="2" auto url="ws://echo.websocket.org"></shared-websocket-component>
+		</template>
+	</test-fixture>
+
+    <script>
+		var websocketElementWithoutURL;
+		var websocketElementWithURLAndSocketId;
+		var websocketElementWithActiveConnection;
+
+		var ws;
+
+		setup(function() {
+			ws = {
+				readyState: 0,
+				send: function(data) {
+					this.onmessage({ 'data': data });
+				},
+				onopen: function() {
+				}
+			};
+			sinon.stub(window, "WebSocket").returns(ws);
+			websocketElementWithoutURL = fixture("websocketComponentWithoutURL");
+		    websocketElementWithoutSocketId = fixture("websocketComponentWithoutSocketId");
+			websocketElementWithURLAndSocketId = fixture("websocketComponentWithURLAndSocketId");
+			websocketElementWithActiveConnection = fixture("websocketComponentWithActiveConnection");
+		});
+
+		teardown(function() {
+			window.WebSocket.restore();
+		});
+
+		suite('<shared-websocket-component>', function() {
+			test('element without url loads ok', function() {
+				expect(websocketElementWithoutURL).to.be.ok;
+			});
+
+			test('open without url throws exception', function() {
+				expect(websocketElementWithoutURL.open).to.throw(Error, 'shared-websocket-component(open): no url specified.');
+			});
+
+			test('close without an open connection throws error', function() {
+				expect(websocketElementWithoutURL.close).to.throw(Error, 'shared-websocket-component(close): not connected.');
+			});
+
+			test('send without an open connection throws error', function() {
+				expect(function() {
+					websocketElementWithoutURL.send("test")
+				}).to.throw(Error, 'websocket-component(send): not connected.');
+			});
+
+			test('element without socket-id throws error', function() {
+			  expect(websocketElementWithoutSocketId.open).to.throw(Error, 'shared-websocket-component(open): no socketId specified.');
+			});
+
+			test('element with a url and a socket-id loads ok', function() {
+				expect(websocketElementWithURLAndSocketId).to.be.ok;
+			});
+
+			test('element status is -1 on load', function() {
+				assert.equal(websocketElementWithURLAndSocketId.status, -1, "The status should be -1");
+			});
+
+			test('element status is 0 after connecting', function() {
+				websocketElementWithURLAndSocketId.open();
+				assert.equal(websocketElementWithURLAndSocketId.status, 0, "The status should be 0");
+			});
+
+			test('element fires an event when the connection is opened', function(done) {
+				websocketElementWithURLAndSocketId.addEventListener('websocket-open', function() {
+					done();
+				});
+				websocketElementWithURLAndSocketId.open();
+				ws.onopen();
+			});
+
+			test('property "auto" connects automatically', function() {
+				assert.equal(websocketElementWithActiveConnection.status, 0, "The status should be 0");
+			});
+
+			test('element fires an event when data is received', function(done) {
+				const data = "test";
+				websocketElementWithActiveConnection.addEventListener('websocket-message', function(event) {
+					assert.equal(event.detail.data, data);
+					done();
+				});
+				websocketElementWithActiveConnection.addEventListener('websocket-open', function() {
+					websocketElementWithActiveConnection.send(data);
+				});
+				ws.onopen();
+			});
+		});
+
+		a11ySuite("websocketComponentWithoutURL");
+    </script>
+  </body>
+</html>

--- a/websocket-component.html
+++ b/websocket-component.html
@@ -18,161 +18,181 @@ Example:
 -->
 
 <dom-module id="websocket-component">
-	<template>
-		<style>
-			:host {
-				display: none;
-			}
-		</style>
-	</template>
-	<script>
-		class WebsocketComponent extends Polymer.Element {
-			static get is() { return "websocket-component"; }
+    <template>
+        <style>
+            :host {
+                display: none;
+            }
+        </style>
+    </template>
+    <script>
+      const WebsocketComponentBehavior = subclass =>class extends subclass {
 
-			static get properties() {
-        return {
-          /**
-           * The url to connect to
-           */
-          url: {
-            type: String,
-            value: "",
-            observer: '_urlChange'
-          },
-          /**
-           * An array of subprotocols for the websocket
-           */
-          protocols: {
-            type: Array,
-            value:  () => []
-          },
-          /**
-           * This status represents the websocket status. Any other element can bind to this status to get updates.
-           */
-          status: {
-            type: Number,
-            readOnly: true,
-            notify: true,
-            value: -1
-          },
-          /**
-           * If this boolean is set, the websocket will automatically connect when the url is specified
-           */
-          auto: {
-            type: Boolean,
-            value: false,
-            observer: '_autoChange'
-          },
-          /**
-           * If this boolean is set, the websocket will automatically close and reopen when the tab/page is out of focus and focussed again respectively
-           */
-          handleVisibility: {
-            type: Boolean,
-            value: false,
-          },
-          _ws: {
-            type: Object,
-            observer: '_wsChange'
+        static get properties() {
+          return {
+            /**
+             * The url to connect to
+             */
+            url: {
+              type: String,
+              value: "", observer: '_urlChange'
+            },
+            /**
+             * An array of subprotocols for the websocket
+             */
+            protocols: {
+              type: Array,
+              value: () => []
+            },
+            /**
+             * This status represents the websocket status. Any other element can bind to this status to get updates.
+             */
+            status: {
+              type: Number,
+              readOnly: true,
+              notify: true,
+              value: -1
+            },
+            /**
+             * If this boolean is set, the websocket will automatically connect when the url is specified
+             */
+            auto: {
+              type: Boolean,
+              value: false,
+              observer: '_autoChange'
+            },
+            /**
+             * If this boolean is set, the websocket will automatically close and reopen when the tab/page is out of focus and focussed again respectively
+             */
+            handleVisibility: {
+              type: Boolean,
+              value: false,
+            },
+            _ws: {
+              type: Object,
+              observer: '_wsChange'
+            }
           }
+        }
+
+        static get observers() {
+          return [
+            '_computeStatus(_ws.readyState)'
+          ]
+        }
+
+        constructor() {
+          super();
+        }
+
+        ready() {
+          super.ready();
+          if (this.handleVisibility && typeof document.hidden !== 'undefined') {
+            document.addEventListener('visibilitychange', this._handleVisibilityChange.bind(this), false);
+          }
+        }
+
+        /**
+         * Open the connection manually. May throw errors when already connected or no url is specified.
+         */
+        open() {
+          if (!this || !this.url || this.url === "") {
+            throw new Error("websocket-component(open): no url specified.");
+          }
+          if (this._ws) {
+            throw new Error("websocket-component(open): already connected");
+          }
+          this._ws = new WebSocket(this.url, this.protocols);
+          this._ws.onopen = this._onwsopen.bind(this);
+          this._ws.onerror = this._onwserror.bind(this);
+          this._ws.onmessage = this._onwsmessage.bind(this);
+          this._ws.onclose = this._onwsclose.bind(this);
+        }
+
+        /**
+         * Send data over the websocket. Throws an error when the websocket is not connected.
+         */
+        send(data) {
+          if (!this._ws) {
+            throw new Error("websocket-component(send): not connected.");
+          }
+          this._ws.send(data);
+        }
+
+        /**
+         * Close the connection manually. Trows an error when the websocket is not connected.
+         */
+        close() {
+          if (!this || !this._ws) {
+            throw new Error("websocket-component(close): not connected.");
+          }
+          this._ws.close();
+          this._ws = null;
+        }
+
+        _onwsopen() {
+          this.dispatchEvent(new CustomEvent("websocket-open"));
+        }
+
+        _onwserror(error) {
+          this._setStatus(-1);
+          this.dispatchEvent(new CustomEvent("websocket-error", {detail: {data: error.data}}));
+        }
+
+        _onwsmessage(event) {
+          this.dispatchEvent(new CustomEvent("websocket-message", {detail: {data: event.data}}));
+        }
+
+        _onwsclose(event) {
+          this._setStatus(-1);
+          this.dispatchEvent(new CustomEvent("websocket-close", {detail: {code: event.code, reason: event.reason}}));
+        }
+
+        _computeStatus(readyState) {
+          if (this._ws) {
+            this._setStatus(this._ws.readyState);
+          }
+          else {
+            this._setStatus(-1);
+          }
+        }
+
+        _urlChange() {
+          if (this.auto && this.url.length > 0) {
+            if (this._ws) {
+              this.close();
+            }
+            this.open();
+          }
+        }
+
+        _autoChange() {
+          if (!this._ws && this.auto && this.url.length > 0) {
+            this.open();
+          }
+        }
+
+        _wsChange() {
+          if (!this._ws) {
+            this._computeStatus(undefined);
+          }
+        }
+
+        _handleVisibilityChange() {
+          if (document.hidden) {
+            this.close();
+          } else {
+            this.open();
+          }
+        }
+      };
+
+      class WebsocketComponent extends WebsocketComponentBehavior(Polymer.Element) {
+        static get is() {
+          return "websocket-component";
         }
       }
 
-			static get observers() {
-        return [
-          '_computeStatus(_ws.readyState)'
-        ]
-      }
-
-      ready() {
-			  super.ready();
-				if (this.handleVisibility && typeof document.hidden !== 'undefined') {
-					document.addEventListener('visibilitychange', this._handleVisibilityChange.bind(this), false);
-				}
-			}
-			/**
-			* Open the connection manually. May throw errors when already connected or no url is specified.
-			*/
-			open() {
-				if(this._ws) {
-					throw new Error("websocket-component(open): already connected");
-				}
-				if(!this.url) {
-					throw new Error("websocket-component(open): no url specified.");
-				}
-				this._ws = new WebSocket(this.url, this.protocols);
-				this._ws.onopen = this._onwsopen.bind(this);
-				this._ws.onerror = this._onwserror.bind(this);
-				this._ws.onmessage = this._onwsmessage.bind(this);
-				this._ws.onclose = this._onwsclose.bind(this);
-			}
-			/**
-			* Send data over the websocket. Throws an error when the websocket is not connected.
-			*/
-			send(data) {
-				if(!this._ws) {
-					throw new Error("websocket-component(send): not connected.");
-				}
-				this._ws.send(data);
-			}
-			/**
-			* Close the connection manually. Trows an error when the websocket is not connected.
-			*/
-			close() {
-				if(!this._ws) {
-					throw new Error("websocket-component(close): not connected.");
-				}
-				this._ws.close();
-				this._ws = null;
-			}
-			_onwsopen() {
-				this.dispatchEvent(new CustomEvent("websocket-open"));
-			}
-			_onwserror(error) {
-				this._setStatus(-1);
-				this.dispatchEvent(new CustomEvent("websocket-error", { detail: { data: error.data}} ));
-			}
-			_onwsmessage(event) {
-				this.dispatchEvent(new CustomEvent("websocket-message", { detail: { data: event.data }} ));
-			}
-			_onwsclose(event) {
-				this._setStatus(-1);
-				this.dispatchEvent(new CustomEvent("websocket-close", { detail: { code: event.code, reason: event.reason }} ));
-			}
-			_computeStatus(readyState) {
-				if(this._ws) {
-					this._setStatus(this._ws.readyState);
-				}
-				else {
-					this._setStatus(-1);
-				}
-			}
-			_urlChange() {
-				if(this.auto && this.url.length > 0) {
-					if(this._ws) {
-						this.close();
-					}
-					this.open();
-				}
-			}
-			_autoChange() {
-				if(!this._ws && this.auto && this.url.length > 0) {
-					this.open();
-				}
-			}
-			_wsChange() {
-				if(!this._ws) {
-					this._computeStatus(undefined);
-				}
-			}
-			_handleVisibilityChange() {
-				if (document.hidden) {
-					this.close();
-				} else {
-					this.open();
-				}
-			}
-		}
-
-		window.customElements.define(WebsocketComponent.is, WebsocketComponent);
-	</script>
+      window.customElements.define(WebsocketComponent.is, WebsocketComponent);
+    </script>
 </dom-module>

--- a/websocket-component.html
+++ b/websocket-component.html
@@ -1,5 +1,7 @@
 <!--
-Copyright (c) 2016 Willem Burgers. All rights reserved.
+Copyright (c) 2016 Willem Burgers.
+							2017 Sebastian Tilsch
+All rights reserved.
 This code may only be used under the BSD style license found at http://wburgers.github.io/LICENSE.txt
 -->
 <link rel="import" href="../polymer/polymer.html">
@@ -24,65 +26,75 @@ Example:
 		</style>
 	</template>
 	<script>
-		Polymer({
-			is: "websocket-component",
-			properties: {
-				/**
-				* The url to connect to
-				*/
-				url: {
-					type: String,
-					value: "",
-					observer: '_urlChange'
-				},
-				/**
-				* An array of subprotocols for the websocket
-				*/
-				protocols: {
-					type: Array,
-					value: function() { return []; }
-				},
-				/**
-				* This status represents the websocket status. Any other element can bind to this status to get updates.
-				*/
-				status: {
-					type: Number,
-					readOnly: true,
-					notify: true,
-					value: -1
-				},
-				/**
-				* If this boolean is set, the websocket will automatically connect when the url is specified
-				*/
-				auto: {
-					type: Boolean,
-					value: false,
-					observer: '_autoChange'
-				},
-				/**
-				* If this boolean is set, the websocket will automatically close and reopen when the tab/page is out of focus and focussed again respectively
-				*/
-				handleVisibility: {
-					type: Boolean,
-					value: false,
-				},
-				_ws: {
-					type: Object,
-					observer: '_wsChange'
-				}
-			},
-			observers: [
-				'_computeStatus(_ws.readyState)'
-			],
-			ready: function () {
+		class WebsocketComponent extends Polymer.Element {
+			static get is() { return "websocket-component"; }
+
+			static get properties() {
+        return {
+          /**
+           * The url to connect to
+           */
+          url: {
+            type: String,
+            value: "",
+            observer: '_urlChange'
+          },
+          /**
+           * An array of subprotocols for the websocket
+           */
+          protocols: {
+            type: Array,
+            value: function () {
+              return [];
+            }
+          },
+          /**
+           * This status represents the websocket status. Any other element can bind to this status to get updates.
+           */
+          status: {
+            type: Number,
+            readOnly: true,
+            notify: true,
+            value: -1
+          },
+          /**
+           * If this boolean is set, the websocket will automatically connect when the url is specified
+           */
+          auto: {
+            type: Boolean,
+            value: false,
+            observer: '_autoChange'
+          },
+          /**
+           * If this boolean is set, the websocket will automatically close and reopen when the tab/page is out of focus and focussed again respectively
+           */
+          handleVisibility: {
+            type: Boolean,
+            value: false,
+          },
+          _ws: {
+            type: Object,
+            observer: '_wsChange'
+          }
+        }
+      }
+
+			static get observers() {
+        return [
+          '_computeStatus(_ws.readyState)'
+        ]
+      }
+
+      ready() {
+			  super.ready();
 				if (this.handleVisibility && typeof document.hidden !== 'undefined') {
 					document.addEventListener('visibilitychange', this._handleVisibilityChange.bind(this), false);
 				}
-			},
+			}
 			/**
 			* Open the connection manually. May throw errors when already connected or no url is specified.
 			*/
-			open: function() {
+			open() {
 				if(this._ws) {
 					throw new Error("websocket-component(open): already connected");
 				}
@@ -94,73 +106,75 @@ Example:
 				this._ws.onerror = this._onwserror.bind(this);
 				this._ws.onmessage = this._onwsmessage.bind(this);
 				this._ws.onclose = this._onwsclose.bind(this);
-			},
+			}
 			/**
 			* Send data over the websocket. Throws an error when the websocket is not connected.
 			*/
-			send: function(data) {
+			send(data) {
 				if(!this._ws) {
 					throw new Error("websocket-component(send): not connected.");
 				}
 				this._ws.send(data);
-			},
+			}
 			/**
 			* Close the connection manually. Trows an error when the websocket is not connected.
 			*/
-			close: function() {
+			close() {
 				if(!this._ws) {
 					throw new Error("websocket-component(close): not connected.");
 				}
 				this._ws.close();
 				this._ws = null;
-			},
-			_onwsopen: function() {
+			}
+			_onwsopen() {
 				this.fire("websocket-open");
-			},
-			_onwserror: function(error) {
+			}
+			_onwserror(error) {
 				this._setStatus(-1);
 				this.fire("websocket-error", {data: error.data});
-			},
-			_onwsmessage: function(event) {
+			}
+			_onwsmessage(event) {
 				this.fire("websocket-message", { data: event.data });
-			},
-			_onwsclose: function(event) {
+			}
+			_onwsclose(event) {
 				this._setStatus(-1);
 				this.fire("websocket-close", { code: event.code, reason: event.reason });
-			},
-			_computeStatus: function(readyState) {
+			}
+			_computeStatus(readyState) {
 				if(this._ws) {
 					this._setStatus(this._ws.readyState);
 				}
 				else {
 					this._setStatus(-1);
 				}
-			},
-			_urlChange: function() {
+			}
+			_urlChange() {
 				if(this.auto && this.url.length > 0) {
 					if(this._ws) {
 						this.close();
 					}
 					this.open();
 				}
-			},
-			_autoChange: function() {
+			}
+			_autoChange() {
 				if(!this._ws && this.auto && this.url.length > 0) {
 					this.open();
 				}
-			},
-			_wsChange: function() {
+			}
+			_wsChange() {
 				if(!this._ws) {
 					this._computeStatus(undefined);
 				}
-			},
-			_handleVisibilityChange: function() {
+			}
+			_handleVisibilityChange() {
 				if (document.hidden) {
 					this.close();
 				} else {
 					this.open();
 				}
 			}
-		});
+		}
+
+		window.customElements.define(WebsocketComponent.is, WebsocketComponent);
 	</script>
 </dom-module>

--- a/websocket-component.html
+++ b/websocket-component.html
@@ -132,7 +132,15 @@ Example:
             }
             this.push('_sendQueue', data);
           } else {
-            this._ws.send(data);
+            try {
+              this._ws.send(data);
+            } catch(error) {
+              if(this.queueIfFailed) {
+                this.push('_sendQueue', data);
+              } else {
+                throw new Error("websocket-component(send): failed.", error);
+              }
+            }
           }
         }
 

--- a/websocket-component.html
+++ b/websocket-component.html
@@ -46,6 +46,7 @@ Example:
             },
             /**
              * This status represents the websocket status. Any other element can bind to this status to get updates.
+             * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#Ready_state_constants
              */
             status: {
               type: Number,
@@ -71,6 +72,18 @@ Example:
             _ws: {
               type: Object,
               observer: '_wsChange'
+            },
+            /**
+             * If this boolean is set, a send-request will be queued, if it failed because of the
+             * websocket not beeing ready. Once the websocket transits into the OPEN state, it sends them one by one
+             */
+            queueIfFailed: {
+              type: Boolean,
+              value: false
+            },
+            _sendQueue: {
+              type: Array,
+              value: () => []
             }
           }
         }
@@ -110,13 +123,17 @@ Example:
         }
 
         /**
-         * Send data over the websocket. Throws an error when the websocket is not connected.
+         * Send data over the websocket. Throws an error when the websocket is not connected and sendIfFailed is not set.
          */
         send(data) {
-          if (!this._ws) {
-            throw new Error("websocket-component(send): not connected.");
+          if (!this._ws || this.status !== 1) {
+            if(!this.queueIfFailed) {
+              throw new Error("websocket-component(send): not connected.");
+            }
+            this.push('_sendQueue', data);
+          } else {
+            this._ws.send(data);
           }
-          this._ws.send(data);
         }
 
         /**
@@ -130,8 +147,21 @@ Example:
           this._ws = null;
         }
 
+        /**
+         * Try to send the send-queue
+         */
+        _processSendQueue() {
+          //we use this iteration method to prevent an infinite loop if send, failes and queue isn't processed
+          const queueLen = this._sendQueue.length;
+          for(let i = queueLen; i > 0; i--) {
+            this.send(this.pop('_sendQueue'));
+          }
+        }
+
         _onwsopen() {
+          this._computeStatus(undefined); //compute status must be executed before any further processing because the send method relies on a correct status
           this.dispatchEvent(new CustomEvent("websocket-open"));
+          this._processSendQueue();
         }
 
         _onwserror(error) {

--- a/websocket-component.html
+++ b/websocket-component.html
@@ -44,9 +44,7 @@ Example:
            */
           protocols: {
             type: Array,
-            value: function () {
-              return [];
-            }
+            value:  () => []
           },
           /**
            * This status represents the websocket status. Any other element can bind to this status to get updates.
@@ -127,18 +125,18 @@ Example:
 				this._ws = null;
 			}
 			_onwsopen() {
-				this.fire("websocket-open");
+				this.dispatchEvent(new CustomEvent("websocket-open"));
 			}
 			_onwserror(error) {
 				this._setStatus(-1);
-				this.fire("websocket-error", {data: error.data});
+				this.dispatchEvent(new CustomEvent("websocket-error", { detail: { data: error.data}} ));
 			}
 			_onwsmessage(event) {
-				this.fire("websocket-message", { data: event.data });
+				this.dispatchEvent(new CustomEvent("websocket-message", { detail: { data: event.data }} ));
 			}
 			_onwsclose(event) {
 				this._setStatus(-1);
-				this.fire("websocket-close", { code: event.code, reason: event.reason });
+				this.dispatchEvent(new CustomEvent("websocket-close", { detail: { code: event.code, reason: event.reason }} ));
 			}
 			_computeStatus(readyState) {
 				if(this._ws) {

--- a/websocket-sharing-behavior.html
+++ b/websocket-sharing-behavior.html
@@ -1,0 +1,39 @@
+<link rel="import" href="../polymer/polymer.html">
+<script>
+  /** @polymerBehavior */
+  const WebsocketSharingBehavior = subclass => class extends subclass {
+
+    static get properties() {
+      return {
+        socketId: {
+          type: String
+        },
+        _websockets: {
+          type: Object,
+          value: new Map()
+        }
+      }
+    }
+
+
+    /**
+     * Tries to get an instance of a websocket by the socketId
+     * If it does not exist it creates a new Websocket
+     * @param socketId
+     * @param socketUrl
+     * @param socketProtocols
+     */
+    getOrCreateSocket(socketUrl, socketProtocols, _socketId) {
+      const socketId = _socketId | this.socketId;
+      if (!this._websockets.has(socketId)) {
+        this._websockets.set(socketId, new WebSocket(socketUrl, socketProtocols));
+      }
+      return this._websockets.get(socketId);
+    }
+
+    removeWebsocket(_socketId) {
+      const socketId = _socketId | this.socketId;
+      this._websockets.delete(socketId)
+    }
+  }
+</script>

--- a/websocket-sharing-behavior.html
+++ b/websocket-sharing-behavior.html
@@ -5,9 +5,16 @@
 
     static get properties() {
       return {
+        /**
+         * The socketId is the identifier for the shared socket, if a socket with the given identifier exists it
+         * will be used, if not, a new one will be created.
+         */
         socketId: {
           type: String
         },
+        /**
+         * a Map of websockets ( identifier -> WebScoket ) that is shared across all instances
+         */
         _websockets: {
           type: Object,
           value: new Map()


### PR DESCRIPTION
Working with webcomponents, it can be very beneficial, not to open a new websocket for every instance of the element. For that purpose I've created a `shared-websocket-component`. I further polished the standard websocket component and enhanced the Polymer-2.0 compatibility of the test and demo pages. There is some weird behavior of the EventListener-registration, that needs to be fixed. It almost looks like a browser bug, but I'm not sure. The bug only occurs in the tests, not in the demo... 