### PR TITLE
Adds JSDoc annotations

### DIFF
--- a/shared-websocket-component.html
+++ b/shared-websocket-component.html
@@ -27,6 +27,10 @@ Example:
 		</style>
 	</template>
 	<script>
+		/**
+		* @extends {Polymer.Element}
+		* @appliesMixin WebsocketComponentBehavior
+		*/
 		class SharedWebsocketComponent extends WebsocketSharingBehavior( WebsocketComponentBehavior(Polymer.Element) ) {
 			static get is() {
 				return "shared-websocket-component";

--- a/websocket-component.html
+++ b/websocket-component.html
@@ -25,6 +25,10 @@ Example:
 		</style>
 	</template>
 	<script>
+		/**
+		* @mixinFunction
+		* @polymer
+		*/
 		const WebsocketComponentBehavior = subclass =>class extends subclass {
 			static get properties() {
 				return {
@@ -230,6 +234,10 @@ Example:
 			}
 		};
 
+		/**
+		* @extends {Polymer.Element}
+		* @appliesMixin WebsocketComponentBehavior
+		*/
 		class WebsocketComponent extends WebsocketComponentBehavior(Polymer.Element) {
 			static get is() {
 				return "websocket-component";


### PR DESCRIPTION
When using  `websocket-component` polymer lint doesn't recognize any of it's properties  triggering
a `[set-unknown-attribute]` lint error. This happens because of missing JSDoc annotations.